### PR TITLE
Fix PaymentResponse example wording for paymentTerms

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@ phone number, or billing address.
 {
   "type": "PaymentResponse",
   "description": "Payment to ExampleMerch for widgets",
-  "payment": {
+  "paymentTerms": {
     "paymentMethod": "https://example.org/cards#VisaLegacy",
     "paymentAmount": {
       "amount": "4.35",


### PR DESCRIPTION
Very minor fix. I was a bit confused by it when I was reading the spec, so thought I would submit this tiny change.
